### PR TITLE
qwen4_exp: PP prefill + PD disaggregation support, validated on 8x RTX 5090

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -29,6 +29,14 @@ class StateType(str, enum.Enum):
     # KV it describes (whole sequence for full attention, window for SWA).
     BLOCK_SCALE = "block_scale"
     BLOCK_SCALE_SWA = "block_scale_swa"
+    # Qwen4-Exp QSA sparse-attention indexer. The compressed index-K cache is
+    # token-page-indexed (compressed slot = full KV slot // ratio, so its
+    # pages mirror full-KV pages 1:1); the pending-group ring + its mRoPE
+    # coordinate tensor are ring-slot-indexed like SWA_RING
+    # (req_pool_idx * ratio + pos % ratio). The indexer is MQA and therefore
+    # TP-replicated: every decode rank receives the full bytes.
+    QSA_COMPRESSED = "qsa_compressed"
+    QSA_RING = "qsa_ring"
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -32,7 +32,7 @@ class StateType(str, enum.Enum):
     # Qwen4-Exp QSA sparse-attention indexer. The compressed index-K cache is
     # token-page-indexed (compressed slot = full KV slot // ratio, so its
     # pages mirror full-KV pages 1:1); the pending-group ring + its mRoPE
-    # coordinate tensor are ring-slot-indexed like SWA_RING
+    # coordinate tensor (positive sentinel id) are ring-slot-indexed like SWA_RING
     # (req_pool_idx * ratio + pos % ratio). The indexer is MQA and therefore
     # TP-replicated: every decode rank receives the full bytes.
     QSA_COMPRESSED = "qsa_compressed"

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -889,7 +889,10 @@ class CommonKVManager(BaseKVManager):
             sock.send_multipart(parts)
 
     def get_mha_kv_ptrs_with_pp(
-        self, src_kv_ptrs: List[int], dst_kv_ptrs: List[int]
+        self,
+        src_kv_ptrs: List[int],
+        dst_kv_ptrs: List[int],
+        dst_layer_ids: Optional[List[int]] = None,
     ) -> Tuple[List[int], List[int], List[int], List[int], int]:
         start_layer = self.kv_args.prefill_start_layer
         num_kv_layers = len(src_kv_ptrs) // 2
@@ -897,6 +900,38 @@ class CommonKVManager(BaseKVManager):
         dst_num_total_layers = len(dst_kv_ptrs) // 2
         src_k_ptrs = src_kv_ptrs[:num_kv_layers]
         src_v_ptrs = src_kv_ptrs[num_kv_layers:]
+
+        # Hybrid-attention models (e.g. qwen4_exp: 36 GDN + 12 full-attn
+        # layers) expose KV pointer lists that are DENSE over the
+        # full-attention layers only, so indexing them with the global
+        # prefill_start_layer below mis-addresses every PP stage but the
+        # first. When both sides shipped kv_layer_ids ([k_ids..., v_ids...],
+        # global layer-id space; the dst list may carry a draft-pool
+        # sentinel tail), pair entries by layer id instead — for non-hybrid
+        # models this reduces to exactly the legacy arithmetic.
+        src_layer_ids = getattr(self.kv_args, "kv_layer_ids", None) or []
+        if (
+            dst_layer_ids
+            and len(src_layer_ids) == len(src_kv_ptrs)
+            and len(dst_layer_ids) == len(dst_kv_ptrs)
+        ):
+            from sglang.srt.disaggregation.utils import build_transfer_entry_pairs
+
+            pairs = build_transfer_entry_pairs(
+                src_layer_ids, dst_layer_ids, len(src_kv_ptrs), len(dst_kv_ptrs)
+            )
+            # src list is [K x n, V x n]; order-preserving pairing maps the K
+            # half onto dst K entries and the V half onto dst V entries even
+            # when the dst list carries a draft tail.
+            dst_k_ptrs = [dst_kv_ptrs[j] for _, j in pairs[:num_kv_layers]]
+            dst_v_ptrs = [dst_kv_ptrs[j] for _, j in pairs[num_kv_layers:]]
+            return (
+                src_k_ptrs,
+                src_v_ptrs,
+                dst_k_ptrs,
+                dst_v_ptrs,
+                num_kv_layers,
+            )
         if num_kv_layers == dst_num_total_layers:
             dst_k_ptrs = dst_kv_ptrs[:dst_num_total_layers]
             dst_v_ptrs = dst_kv_ptrs[dst_num_total_layers:]

--- a/python/sglang/srt/disaggregation/common/staging_handler.py
+++ b/python/sglang/srt/disaggregation/common/staging_handler.py
@@ -101,6 +101,12 @@ class DecodeStagingHandler:
         # room -> chunk_idx -> [(page_start, num_pages, writer_id)] fan-in
         # arrivals; handler-owned so room teardown can purge them.
         self._writer_counts: dict = {}
+        # room -> [(ts, chunk_idx, page_start, num_pages, writer_id)]:
+        # CHUNK_READY can beat the room's register_decode_req (likely on the
+        # nvlink transport, where the RDMA completes in microseconds);
+        # dropping those arrivals starves the writer fan-in and the room dies
+        # at the 300 s transfer timeout. Stash and replay at registration.
+        self._pending_arrivals: dict = {}
 
     def register_wm_subscriber(self, receiver, session_id: str) -> None:
         """Register a prefill's bootstrap connection for watermark broadcasts."""
@@ -166,6 +172,13 @@ class DecodeStagingHandler:
         decode_req._chunk_events = []
         self._room_to_decode_req[room] = decode_req
         self._room_to_receiver[room] = decode_req.kv_receiver
+        # Replay arrivals that beat this registration (order: receiver stash
+        # is visible FIRST, so a concurrent arrival takes the normal path and
+        # the per-writer dedup absorbs any overlap with the replay).
+        for _ts, p_chunk, p_start, p_pages, p_writer in self._pending_arrivals.pop(
+            room, []
+        ):
+            self.handle_chunk_arrived(room, p_chunk, p_start, p_pages, p_writer)
         # Scatter offsets shift suffix-relative page_start by the decode prefix,
         # exact only when the prefix is page-aligned. Fail just this request on a
         # mismatch instead of raising, which would kill the prefill scheduler.
@@ -290,14 +303,33 @@ class DecodeStagingHandler:
         # nulls the latter before unregister removes the room.
         receiver = self._room_to_receiver.get(room)
         if receiver is None:
-            logger.warning(
-                "Staging chunk arrived for unregistered room=%s chunk=%d, " "skipping",
+            # Not (yet) registered: stash for replay instead of dropping --
+            # register_decode_req may simply not have run yet. Prune rooms
+            # whose arrivals went unclaimed for 120 s (aborted/failed).
+            now = time.monotonic()
+            for stale in [
+                r
+                for r, entries in self._pending_arrivals.items()
+                if entries and now - entries[0][0] > 120.0
+            ]:
+                del self._pending_arrivals[stale]
+            self._pending_arrivals.setdefault(room, []).append(
+                (now, chunk_idx, page_start, num_pages, writer_id)
+            )
+            logger.info(
+                "Staging chunk arrived before room registration, stashed: "
+                "room=%s chunk=%d writer=%s",
                 room,
                 chunk_idx,
+                writer_id,
             )
             return False
         room_counts = self._writer_counts.setdefault(room, {})
         arrivals = room_counts.setdefault(chunk_idx, [])
+        if any(w == writer_id for _, _, w in arrivals):
+            # Duplicate (keepalive resend or stash replay racing a live
+            # arrival) -- counting it twice would fire the scatter early.
+            return False
         arrivals.append((page_start, num_pages, writer_id))
         num_writers = self.num_writers_for(receiver)
         if len(arrivals) >= num_writers:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -575,8 +575,9 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 # addresses the main entries correctly by layer id. Blanking
                 # the ids here (old behavior) broke hybrid-model PP prefill
                 # + NEXTN decode: the global-index fallback mis-addresses
-                # the dense full-attention pointer lists.
-                kv_layer_ids += [-1000 - i for i in range(len(draft_kv_data_ptrs))]
+                # the dense full-attention pointer lists. Sentinels must be
+                # POSITIVE (ids pack as unsigned 32-bit in the bootstrap).
+                kv_layer_ids += [1_000_000 + i for i in range(len(draft_kv_data_ptrs))]
             kv_args.kv_layer_ids = kv_layer_ids
         else:
             kv_args.kv_layer_ids = []

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -238,6 +238,10 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
         linear_replayssm_cache_len: int = 16,
         mamba_envelope_layout: bool = False,
         enable_linear_replayssm_spec: bool = False,
+        short_conv_layer_ids: Optional[List[int]] = None,
+        short_conv_state_shape=None,
+        ngram_context_len: int = 0,
+        ngram_eos_token_id: int = 0,
     ):
         DecodeReqToTokenPool.__init__(
             self,
@@ -285,6 +289,12 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
             linear_replayssm_cache_len=linear_replayssm_cache_len,
             mamba_envelope_layout=mamba_envelope_layout,
             enable_linear_replayssm_spec=enable_linear_replayssm_spec,
+            # Qwen4-Exp PLE slot pools: without these the first decode
+            # forward asserts on a disabled ShortConvPool/NGramPool.
+            short_conv_layer_ids=short_conv_layer_ids,
+            short_conv_state_shape=short_conv_state_shape,
+            ngram_context_len=ngram_context_len,
+            ngram_eos_token_id=ngram_eos_token_id,
         )
 
     def clear(self):
@@ -555,12 +565,21 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         kv_args.kv_data_ptrs = kv_data_ptrs
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
-        kv_args.kv_layer_ids = (
-            self.token_to_kv_pool.get_kv_layer_ids()
-            if self.draft_token_to_kv_pool is None
-            and hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
-            else []
-        )
+        if hasattr(self.token_to_kv_pool, "get_kv_layer_ids"):
+            kv_layer_ids = list(self.token_to_kv_pool.get_kv_layer_ids())
+            if self.draft_token_to_kv_pool is not None:
+                # Keep layer-id pairing alive alongside a draft pool: the
+                # draft entries (appended after [K_main..., V_main...]) get
+                # unique sentinel ids no prefill publishes, so they are never
+                # paired -- a spec-less (e.g. PP>1) prefill then still
+                # addresses the main entries correctly by layer id. Blanking
+                # the ids here (old behavior) broke hybrid-model PP prefill
+                # + NEXTN decode: the global-index fallback mis-addresses
+                # the dense full-attention pointer lists.
+                kv_layer_ids += [-1000 - i for i in range(len(draft_kv_data_ptrs))]
+            kv_args.kv_layer_ids = kv_layer_ids
+        else:
+            kv_args.kv_layer_ids = []
         if self.transfer_backend == TransferBackend.NIXL:
             kv_args.kv_data_mem_kinds = kv_data_mem_kinds
         kv_args.page_size = self.token_to_kv_pool.page_size
@@ -1427,6 +1446,16 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     ring_size=ring_size,
                 )
 
+            def _qsa_ring_payload():
+                # Mirror of prefill _qsa_ring_payload using this side's
+                # req_pool_idx; same positions and order -> positional match.
+                ratio = self.token_to_kv_pool.qsa_compress_ratio
+                window_start = max(0, seq_len - ratio)
+                positions = np.arange(window_start, seq_len, dtype=np.int64)
+                state_slot = int(decode_req.req.req_pool_idx)
+                ring_rows = state_slot * ratio + (positions % ratio)
+                return ring_rows.astype(np.int32)
+
             state_types = self.kv_manager.kv_args.state_types
             if StateType.C128_STATE in state_types:
                 clear_c128_state = getattr(
@@ -1443,7 +1472,39 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 StateType.C128_STATE: _c128_state_payload,
                 StateType.BLOCK_SCALE: _full_kv_pages_payload,
                 StateType.BLOCK_SCALE_SWA: _swa_payload,
+                StateType.QSA_COMPRESSED: _full_kv_pages_payload,
+                StateType.QSA_RING: _qsa_ring_payload,
             }
+
+            # Qwen4-Exp PLE: the n-gram context pool is a slot sibling that is
+            # not part of the transfer payloads, but its content is exactly
+            # the prompt tail -- reconstruct it locally so the first
+            # (ngram_size-1) decoded tokens hash real context instead of the
+            # EOS fill. (The PLE short-conv window is NOT reconstructible and
+            # currently starts zeroed after PD handoff -- affects only the
+            # first few tokens' PLE injection.)
+            ngram_pool = getattr(self.req_to_token_pool, "ngram_pool", None)
+            if ngram_pool is not None and getattr(ngram_pool, "enabled", False):
+                ctx_len = ngram_pool.context.shape[1]
+                tail = list(decode_req.req.origin_input_ids[-ctx_len:])
+                if len(tail) < ctx_len:
+                    tail = [
+                        int(ngram_pool.eos_token_id)
+                    ] * (ctx_len - len(tail)) + tail
+                req_idx_t = torch.tensor(
+                    [decode_req.req.req_pool_idx],
+                    dtype=torch.long,
+                    device=ngram_pool.context.device,
+                )
+                ngram_indices = self.req_to_token_pool.get_ngram_indices(req_idx_t)
+                self.req_to_token_pool.set_ngram_context(
+                    ngram_indices,
+                    torch.tensor(
+                        [tail],
+                        dtype=ngram_pool.context.dtype,
+                        device=ngram_pool.context.device,
+                    ),
+                )
             if _is_npu and isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
                 from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
                     dsv4_state_payloads,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -235,7 +235,8 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             )
             self.executors = [
                 concurrent.futures.ThreadPoolExecutor(
-                    transfer_thread_pool_size // transfer_queue_size
+                    transfer_thread_pool_size // transfer_queue_size,
+                    initializer=self._pin_transfer_device,
                 )
                 for _ in range(transfer_queue_size)
             ]
@@ -302,12 +303,30 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     regions.append((ptr, length))
 
         add(self.kv_args.kv_data_ptrs, self.kv_args.kv_data_lens)
-        add(self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens)
+        # GPU-only transports (nvlink_intra) reject host memory and abort the
+        # whole registration batch on it, which would leave the state pools
+        # (added after aux) unregistered. With aux shipped via the TCP
+        # side-channel the aux buffers never touch the engine, so skip them.
+        if not envs.SGLANG_MOONCAKE_SEND_AUX_TCP.get():
+            add(self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens)
         for ptrs, lens in zip(
             self.kv_args.state_data_ptrs, self.kv_args.state_data_lens
         ):
             add(ptrs, lens)
         return regions
+
+    def _pin_transfer_device(self) -> None:
+        # Transfer threads never set a CUDA device, so lazy CUDA init lands on
+        # device 0. Harmless for the TCP transport, fatal for nvlink_intra:
+        # the transport's streams and cudaIpcOpenMemHandle then run in the
+        # wrong device context ("invalid device context" opens, segfaults
+        # under concurrency -- qwen-3.8-27b FINDINGS S17).
+        try:
+            import torch
+
+            torch.cuda.set_device(self.kv_args.gpu_id)
+        except Exception:
+            pass
 
     def register_buffer_to_engine(self):
         regions = self._registerable_regions()
@@ -747,7 +766,10 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 transfer_blocks.extend(set_transfer_blocks(src_ptr, dst_ptr, item_len))
             return self._transfer_data(mooncake_session_id, transfer_blocks)
 
-        if self.enable_custom_mem_pool:
+        # Parallel per-layer submission stays off for nvlink_intra: a single
+        # batched submit at ~40 GB/s is plenty and the parallel path was the
+        # segfault context (qwen-3.8-27b FINDINGS S17).
+        if self.enable_custom_mem_pool and self.custom_mem_pool_type != "INTRA_NODE_NVLINK":
             futures = [
                 executor.submit(
                     process_layer,
@@ -948,7 +970,9 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 set_transfer_blocks(src_ptr, dst_ptr, token_item_len),
             )
 
-        if self.enable_custom_mem_pool:
+        # See the matching guard above: no parallel per-layer path for
+        # nvlink_intra.
+        if self.enable_custom_mem_pool and self.custom_mem_pool_type != "INTRA_NODE_NVLINK":
             futures = [
                 executor.submit(process_layer, src_ptr, dst_ptr, token_item_len)
                 for src_ptr, dst_ptr, token_item_len in layers_params
@@ -1619,6 +1643,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         staging_buffer=None,
         worker_index=0,
     ):
+        self._pin_transfer_device()
         staging_strategy = None
         if self.enable_trace:
             trace_set_thread_info(
@@ -2103,6 +2128,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
 
     def start_decode_thread(self):
         def decode_thread():
+            self._pin_transfer_device()
             while True:
                 msg = self.server_socket.recv_multipart()
                 if msg[0] == MooncakeKVManager.AUX_DATA_HEADER:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1392,7 +1392,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 # and TP-replicated, so heterogeneous attn TP is fine: every
                 # decode rank receives the full bytes. Tensor lists are flat
                 # per-layer (plus a layer-independent mRoPE tensor in the ring
-                # component, sentinel id -1 on both peers) -> force_flat with
+                # component, fixed positive sentinel id on both peers) -> force_flat with
                 # layer-id pairing, which also addresses the decode's dense
                 # lists correctly from any PP stage.
                 src_indices = list(indices)

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -684,7 +684,9 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 ]
         else:
             src_k_ptrs, src_v_ptrs, dst_k_ptrs, dst_v_ptrs, layers_current_pp_stage = (
-                self.get_mha_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs)
+                self.get_mha_kv_ptrs_with_pp(
+                    src_data_ptrs, dst_data_ptrs, dst_layer_ids=dst_layer_ids
+                )
             )
             # item_lens structure: [k_layer0, k_layer1, ..., k_layerN, v_layer0, v_layer1, ..., v_layerN]
             # Use correct item lengths for K and V separately
@@ -970,6 +972,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         dst_attn_tp_size: int,
         dst_kv_item_len: int,
         executor: concurrent.futures.ThreadPoolExecutor,
+        dst_layer_ids: Optional[list[int]] = None,
     ):
         """
         Sends KV cache slices from this Prefill rank to a target Decode rank,
@@ -1023,7 +1026,9 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             dst_head_start_offset = 0
 
         src_k_ptrs, src_v_ptrs, dst_k_ptrs, dst_v_ptrs, layers_current_pp_stage = (
-            self.get_mha_kv_ptrs_with_pp(self.kv_args.kv_data_ptrs, dst_kv_ptrs)
+            self.get_mha_kv_ptrs_with_pp(
+                self.kv_args.kv_data_ptrs, dst_kv_ptrs, dst_layer_ids=dst_layer_ids
+            )
         )
 
         # Calculate precise byte offset and length for the sub-slice within the token
@@ -1378,6 +1383,41 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         prefill_data_indices=np.array(src_indices, dtype=np.int32),
                         dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
                         executor=executor,
+                        state_type=st,
+                    )
+                    or rc
+                )
+            elif st in (StateType.QSA_COMPRESSED, StateType.QSA_RING):
+                # Qwen4-Exp QSA indexer state. The indexer is MQA (1 KV head)
+                # and TP-replicated, so heterogeneous attn TP is fine: every
+                # decode rank receives the full bytes. Tensor lists are flat
+                # per-layer (plus a layer-independent mRoPE tensor in the ring
+                # component, sentinel id -1 on both peers) -> force_flat with
+                # layer-id pairing, which also addresses the decode's dense
+                # lists correctly from any PP stage.
+                src_indices = list(indices)
+                dst_indices_local = list(dst_indices)
+                if len(src_indices) != len(dst_indices_local):
+                    # Positionally matched rows/pages; truncation would
+                    # silently misalign and corrupt the indexer state.
+                    raise RuntimeError(
+                        f"{st.upper()} state index length mismatch: "
+                        f"prefill={len(src_indices)}, dst={len(dst_indices_local)}"
+                    )
+                if len(src_indices) == 0:
+                    continue
+                rc = (
+                    self._send_kvcache_generic(
+                        mooncake_session_id=req.mooncake_session_id,
+                        src_data_ptrs=src_data_ptrs,
+                        dst_data_ptrs=dst_data_ptrs,
+                        item_lens=src_item_lens,
+                        prefill_data_indices=np.array(src_indices, dtype=np.int32),
+                        dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
+                        executor=executor,
+                        force_flat=True,
+                        src_layer_ids=src_state_layer_ids,
+                        dst_layer_ids=dst_state_layer_ids,
                         state_type=st,
                     )
                     or rc
@@ -1786,6 +1826,9 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                                 target_rank_registration_info.dst_attn_tp_size,
                                 target_rank_registration_info.dst_kv_item_len,
                                 executor,
+                                dst_layer_ids=(
+                                    target_rank_registration_info.dst_kv_layer_ids
+                                ),
                             )
                         if ret != 0:
                             with self.session_lock:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1406,22 +1406,24 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     )
                 if len(src_indices) == 0:
                     continue
-                rc = (
-                    self._send_kvcache_generic(
-                        mooncake_session_id=req.mooncake_session_id,
-                        src_data_ptrs=src_data_ptrs,
-                        dst_data_ptrs=dst_data_ptrs,
-                        item_lens=src_item_lens,
-                        prefill_data_indices=np.array(src_indices, dtype=np.int32),
-                        dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
-                        executor=executor,
-                        force_flat=True,
-                        src_layer_ids=src_state_layer_ids,
-                        dst_layer_ids=dst_state_layer_ids,
-                        state_type=st,
-                    )
-                    or rc
+                qsa_rc = self._send_kvcache_generic(
+                    mooncake_session_id=req.mooncake_session_id,
+                    src_data_ptrs=src_data_ptrs,
+                    dst_data_ptrs=dst_data_ptrs,
+                    item_lens=src_item_lens,
+                    prefill_data_indices=np.array(src_indices, dtype=np.int32),
+                    dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
+                    executor=executor,
+                    force_flat=True,
+                    src_layer_ids=src_state_layer_ids,
+                    dst_layer_ids=dst_state_layer_ids,
+                    state_type=st,
                 )
+                logger.debug(
+                    f"[QSA-XFER] {st.value} rc={qsa_rc} tensors={len(src_data_ptrs)}->"
+                    f"{len(dst_data_ptrs)} n_idx={len(src_indices)}"
+                )
+                rc = qsa_rc or rc
             elif st == StateType.MINIMAX_INDEX_K:
                 # Equal-TP / PP=1 only. Sub-pools are compacted sparse-layer
                 # lists, so PP>1 mis-slices and heterogeneous TP is unsupported.

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -2141,7 +2141,16 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     chunk_idx = int(msg[2].decode("ascii"))
                     page_start = int(msg[3].decode("ascii"))
                     num_pages = int(msg[4].decode("ascii"))
-                    session_id = msg[5].decode("ascii")
+                    # msg[5] is the decode-session id -- IDENTICAL for every
+                    # prefill PP stage writing to this rank, so it cannot be
+                    # the fan-in writer identity. msg[6] carries the sender's
+                    # prefill_unique_rank (always sent, was never parsed);
+                    # the arrival dedup in handle_chunk_arrived needs it.
+                    writer_id = (
+                        msg[6].decode("ascii")
+                        if len(msg) > 6
+                        else msg[5].decode("ascii")
+                    )
                     handler = self._staging_handler
                     assert (
                         handler is not None
@@ -2151,7 +2160,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         chunk_idx,
                         page_start,
                         num_pages,
-                        session_id,
+                        writer_id,
                     )
                     continue
 

--- a/python/sglang/srt/disaggregation/mooncake/utils.py
+++ b/python/sglang/srt/disaggregation/mooncake/utils.py
@@ -56,7 +56,23 @@ def init_mooncake_custom_mem_pool(
 
                 allocator = BarexAllocator.get_allocator(device)
             elif custom_mem_pool_type == "INTRA_NODE_NVLINK":
-                return False, None, None
+                # Plain-cudaMalloc pool (qwen-3.8-27b FINDINGS S17): keeps
+                # pool memory cudaIpcGetMemHandle-exportable for the
+                # intranode nvlink transport while the REST of the process
+                # keeps expandable segments (expandable_segments:False costs
+                # ~6x on concurrent cold chunked prefill). The .so forwards
+                # to cudaMalloc/cudaFree.
+                import os
+
+                from torch.cuda.memory import CUDAPluggableAllocator
+
+                so_path = os.environ.get(
+                    "SGLANG_PLAIN_CUDAMALLOC_ALLOCATOR_SO",
+                    "/opt/libplaincudamalloc.so",
+                )
+                allocator = CUDAPluggableAllocator(
+                    so_path, "plain_malloc", "plain_free"
+                )
             else:
                 # This should not happen due to the enable_custom_mem_pool check above
                 raise ValueError(

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -1239,6 +1239,20 @@ class SchedulerDisaggregationPrefillMixin:
                     ring_size=ring_size,
                 )
 
+            def _qsa_ring_payload():
+                # QSA pending-group ring rows (req_pool_idx*ratio + pos%ratio)
+                # for the last `ratio` positions, ascending position order so
+                # the decode peer (its own req_pool_idx) matches positionally.
+                # Rows of already-compressed positions transfer as harmless
+                # staleness -- they are never read again.
+                _pool = self.token_to_kv_pool_allocator.get_kvcache()
+                ratio = _pool.qsa_compress_ratio
+                window_start = max(0, seq_len - ratio)
+                positions = np.arange(window_start, seq_len, dtype=np.int64)
+                state_slot = int(req.req_pool_idx)
+                ring_rows = state_slot * ratio + (positions % ratio)
+                return ring_rows.astype(np.int32)
+
             state_types = (
                 self.disagg_prefill_bootstrap_queue.kv_manager.kv_args.state_types
             )
@@ -1251,6 +1265,8 @@ class SchedulerDisaggregationPrefillMixin:
                 StateType.C128_STATE: _c128_state_payload,
                 StateType.BLOCK_SCALE: _full_kv_pages_payload,
                 StateType.BLOCK_SCALE_SWA: _swa_payload,
+                StateType.QSA_COMPRESSED: _full_kv_pages_payload,
+                StateType.QSA_RING: _qsa_ring_payload,
             }
             if _is_npu and isinstance(
                 self.token_to_kv_pool_allocator.get_kvcache(),

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1273,6 +1273,14 @@ def setup_state_kv_args(
                 slice_outer_counts,
             )
 
+    import logging
+
+    logging.getLogger(__name__).info(
+        f"[STATE-REG] pool={type(token_to_kv_pool).__name__} "
+        f"req_pool={type(req_to_token_pool).__name__} "
+        f"types={[t.value for t in kv_args.state_types]}"
+    )
+
 
 def prepare_abort(req: Req, error_message: str, status_code=None):
     from sglang.srt.managers.schedule_batch import FINISH_ABORT

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1103,6 +1103,35 @@ def setup_state_kv_args(
                 slice_outer_counts,
                 layer_ids,
             )
+            # Qwen4-Exp QSA indexer state: without these components the
+            # decode's sparse top-k reads zeroed compressed keys for the
+            # whole transferred prefix -> silently wrong output past the
+            # indexer budget.
+            if hasattr(token_to_kv_pool, "get_qsa_compressed_buf_infos"):
+                qc_ptrs, qc_lens, qc_item_lens, qc_layer_ids = (
+                    token_to_kv_pool.get_qsa_compressed_buf_infos()
+                )
+                if qc_ptrs:
+                    append_state_component(
+                        kv_args,
+                        StateType.QSA_COMPRESSED,
+                        qc_ptrs,
+                        qc_lens,
+                        qc_item_lens,
+                        layer_ids=qc_layer_ids,
+                    )
+                qr_ptrs, qr_lens, qr_item_lens, qr_layer_ids = (
+                    token_to_kv_pool.get_qsa_ring_buf_infos()
+                )
+                if qr_ptrs:
+                    append_state_component(
+                        kv_args,
+                        StateType.QSA_RING,
+                        qr_ptrs,
+                        qr_lens,
+                        qr_item_lens,
+                        layer_ids=qr_layer_ids,
+                    )
         elif isinstance(token_to_kv_pool, (DSATokenToKVPool, NPUMLATokenToKVPool)):
             if draft_token_to_kv_pool is not None and isinstance(
                 draft_token_to_kv_pool, DSATokenToKVPool

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -1368,8 +1368,31 @@ class _MambaStrategy(StackStrategy):
         model_name=None,
         enable_storage_metrics=False,
     ):
-        full_layer_mapping = dict(kvcache.full_attention_layer_id_mapping)
-        mamba_layer_mapping = dict(params.req_to_token_pool.mamba_map)
+        # Rebase mapping KEYS to dense stage-local ids: the pools key these by
+        # GLOBAL layer id, but the L2 engine's H->D loop iterates
+        # range(transfer_layer_num) (a COUNT) and looks up with dict.get() --
+        # at pp_rank>0 every global key sits above the range, so every
+        # per-layer host-to-device load was a silent no-op (KV, mamba AND the
+        # QSA entry, which reuses full_layer_mapping) while D->H backups and
+        # the slot-sibling PLE restore kept working. Identity at PP0. Same
+        # convention as the DeepSeek-V4 builder above; the consumers already
+        # wait on `layer_id - start_layer`.
+        start_layer = kvcache.start_layer
+        mamba_start = params.req_to_token_pool.start_layer
+        full_layer_mapping = {
+            gid - start_layer: local
+            for gid, local in kvcache.full_attention_layer_id_mapping.items()
+        }
+        mamba_layer_mapping = {
+            gid - mamba_start: local
+            for gid, local in params.req_to_token_pool.mamba_map.items()
+        }
+        keys = sorted(full_layer_mapping | mamba_layer_mapping)
+        if keys != list(range(len(keys))):
+            raise ValueError(
+                "HiCache hybrid layer mapping must be dense stage-local, got "
+                f"{keys} (start_layer={start_layer}, mamba_start={mamba_start})"
+            )
         host_pool_group, cache_controller = build_hybrid_mamba_stack(
             params=params,
             server_args=server_args,

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -801,6 +801,20 @@ class KVCacheConfigurator:
         from sglang.srt.disaggregation.decode import (
             HybridMambaDecodeReqToTokenPool,
         )
+        from sglang.srt.configs.qwen4_exp import Qwen4ExpTextConfig
+
+        ple_kwargs = {}
+        if isinstance(self.mambaish_config, Qwen4ExpTextConfig):
+            ple_kwargs = dict(
+                short_conv_layer_ids=[
+                    i
+                    for i in self.mambaish_config.short_conv_layer_ids
+                    if self.layer_info.start_layer <= i < self.layer_info.end_layer
+                ],
+                short_conv_state_shape=self.mambaish_config.short_conv_state_shape,
+                ngram_context_len=self.mambaish_config.ngram_context_len,
+                ngram_eos_token_id=int(self.mambaish_config.eos_token_id),
+            )
 
         req_to_token_pool = HybridMambaDecodeReqToTokenPool(
             size=max_num_reqs,

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -836,6 +836,7 @@ class KVCacheConfigurator:
             enable_overlap_schedule=not get_schedule().disable_overlap_schedule,
             mamba_size=get_schedule().max_mamba_cache_size,
             start_layer=self.layer_info.start_layer,
+            **ple_kwargs,
             linear_replayssm_cache_len=get_exec().mamba.linear_replayssm_cache_len,
             mamba_envelope_layout=get_memory().enable_page_major_kv_layout,
             # ReplaySSM spec-verify is for linear-attn models (GDN fold or KDA

--- a/python/sglang/srt/mem_cache/qsa_kv_pool.py
+++ b/python/sglang/srt/mem_cache/qsa_kv_pool.py
@@ -181,6 +181,47 @@ class QSATokenToKVPool(HybridLinearKVPool):
         k_size, v_size = self.get_kv_size_bytes()
         self.mem_usage = (k_size + v_size) / GB
 
+    def get_qsa_compressed_buf_infos(self):
+        """PD-transfer metadata for the compressed index-K cache.
+
+        Returns (data_ptrs, data_lens, item_lens, layer_ids): one entry per
+        local full-attention layer, item_len = bytes of one full-KV page's
+        worth of compressed rows (pages mirror full-KV pages 1:1), layer ids
+        in the global layer-id space for cross-PP pairing.
+        """
+        dtype_size = self.qsa_compressed_flat.element_size()
+        row_bytes = self.qsa_index_kv_heads * self.qsa_index_head_dim * dtype_size
+        page_bytes = self.qsa_compressed_page_size * row_bytes
+        ptrs, lens, item_lens = [], [], []
+        for t in self.qsa_compressed_k_buffer_pool:
+            ptrs.append(t.data_ptr())
+            lens.append(t.numel() * dtype_size)
+            item_lens.append(page_bytes)
+        layer_ids = list(self.full_attention_layer_id_mapping)
+        return ptrs, lens, item_lens, layer_ids
+
+    def get_qsa_ring_buf_infos(self):
+        """PD-transfer metadata for the pending-group ring + mRoPE coords.
+
+        Ring rows are addressed req_pool_idx * ratio + pos % ratio; item_len
+        is one ring row. The layer-independent mRoPE tensor rides as the
+        last entry with sentinel layer id -1 (present on both peers).
+        """
+        ptrs, lens, item_lens = [], [], []
+        for t in self.qsa_key_state_buffer_pool:
+            dtype_size = t.element_size()
+            row_bytes = self.qsa_index_kv_heads * self.qsa_index_head_dim * dtype_size
+            ptrs.append(t.data_ptr())
+            lens.append(t.numel() * dtype_size)
+            item_lens.append(row_bytes)
+        layer_ids = list(self.full_attention_layer_id_mapping)
+        rope = self.qsa_rope_position_buffer
+        ptrs.append(rope.data_ptr())
+        lens.append(rope.numel() * rope.element_size())
+        item_lens.append(rope.shape[1] * rope.element_size())
+        layer_ids.append(-1)
+        return ptrs, lens, item_lens, layer_ids
+
     def get_qsa_key_state_buffer(self, layer_id: int) -> torch.Tensor:
         return self.qsa_key_state_buffer_pool[
             self._transfer_full_attention_id(layer_id)

--- a/python/sglang/srt/mem_cache/qsa_kv_pool.py
+++ b/python/sglang/srt/mem_cache/qsa_kv_pool.py
@@ -205,7 +205,8 @@ class QSATokenToKVPool(HybridLinearKVPool):
 
         Ring rows are addressed req_pool_idx * ratio + pos % ratio; item_len
         is one ring row. The layer-independent mRoPE tensor rides as the
-        last entry with sentinel layer id -1 (present on both peers).
+        last entry under a fixed sentinel layer id (present on both peers;
+        positive because the bootstrap packs layer ids as unsigned 32-bit).
         """
         ptrs, lens, item_lens = [], [], []
         for t in self.qsa_key_state_buffer_pool:
@@ -219,7 +220,7 @@ class QSATokenToKVPool(HybridLinearKVPool):
         ptrs.append(rope.data_ptr())
         lens.append(rope.numel() * rope.element_size())
         item_lens.append(rope.shape[1] * rope.element_size())
-        layer_ids.append(-1)
+        layer_ids.append(999_999)
         return ptrs, lens, item_lens, layer_ids
 
     def get_qsa_key_state_buffer(self, layer_id: int) -> torch.Tensor:

--- a/python/sglang/srt/mem_cache/qsa_kv_pool.py
+++ b/python/sglang/srt/mem_cache/qsa_kv_pool.py
@@ -8,6 +8,7 @@ Qwen3Next-DSA) adds only the flat per-token index-K cache.
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from typing import List, Optional
 
 import torch
@@ -144,32 +145,42 @@ class QSATokenToKVPool(HybridLinearKVPool):
             )
         self.qsa_num_request_slots = int(num_request_slots)
         ring_slots = self.qsa_num_request_slots * self.qsa_compress_ratio
-        self.qsa_key_state_buffer_pool = [
-            torch.zeros(
-                (ring_slots, self.qsa_index_kv_heads, self.qsa_index_head_dim),
+        # These buffers are PD-transferred (QSA_COMPRESSED/QSA_RING state
+        # components), so GPU-only transports (nvlink_intra) register them
+        # with the engine: allocate from the IPC-exportable custom pool like
+        # the KV buffers, or cudaIpcGetMemHandle fails on expandable
+        # segments and the whole registration batch aborts.
+        with (
+            torch.cuda.use_mem_pool(self.custom_mem_pool)
+            if self.enable_custom_mem_pool
+            else nullcontext()
+        ):
+            self.qsa_key_state_buffer_pool = [
+                torch.zeros(
+                    (ring_slots, self.qsa_index_kv_heads, self.qsa_index_head_dim),
+                    dtype=self.index_state_dtype,
+                    device=device,
+                )
+                for _ in full_attention_layer_ids
+            ]
+            # RoPE coordinates are layer-independent.  Keep the exact Qwen4-Exp MRoPE
+            # position of every pending key so compression can rotate the pooled
+            # key with the group's real starting coordinate.
+            self.qsa_rope_position_buffer = torch.zeros(
+                (ring_slots, 3), dtype=torch.int64, device=device
+            )
+            # One contiguous allocation behind per-layer views: every layer's
+            # compressed pages are addressable from a single base pointer.
+            self.qsa_compressed_flat = torch.zeros(
+                (
+                    len(full_attention_layer_ids),
+                    self.qsa_compressed_capacity
+                    * self.qsa_index_kv_heads
+                    * self.qsa_index_head_dim,
+                ),
                 dtype=self.index_state_dtype,
                 device=device,
             )
-            for _ in full_attention_layer_ids
-        ]
-        # RoPE coordinates are layer-independent.  Keep the exact Qwen4-Exp MRoPE
-        # position of every pending key so compression can rotate the pooled
-        # key with the group's real starting coordinate.
-        self.qsa_rope_position_buffer = torch.zeros(
-            (ring_slots, 3), dtype=torch.int64, device=device
-        )
-        # One contiguous allocation behind per-layer views: every layer's
-        # compressed pages are addressable from a single base pointer.
-        self.qsa_compressed_flat = torch.zeros(
-            (
-                len(full_attention_layer_ids),
-                self.qsa_compressed_capacity
-                * self.qsa_index_kv_heads
-                * self.qsa_index_head_dim,
-            ),
-            dtype=self.index_state_dtype,
-            device=device,
-        )
         self.qsa_compressed_k_buffer_pool = [
             self.qsa_compressed_flat[layer_offset].view(
                 self.qsa_compressed_capacity,

--- a/python/sglang/srt/mem_cache/qsa_kv_pool.py
+++ b/python/sglang/srt/mem_cache/qsa_kv_pool.py
@@ -151,8 +151,8 @@ class QSATokenToKVPool(HybridLinearKVPool):
         # the KV buffers, or cudaIpcGetMemHandle fails on expandable
         # segments and the whole registration batch aborts.
         with (
-            torch.cuda.use_mem_pool(self.custom_mem_pool)
-            if self.enable_custom_mem_pool
+            torch.cuda.use_mem_pool(self.full_kv_pool.custom_mem_pool)
+            if self.full_kv_pool.enable_custom_mem_pool
             else nullcontext()
         ):
             self.qsa_key_state_buffer_pool = [

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -44,9 +44,13 @@ from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scat
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
-from sglang.srt.layers.utils import get_layer_id
+from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_batch_info import (
+    ForwardBatch,
+    ForwardMode,
+    PPProxyTensors,
+)
 from sglang.srt.model_executor.forward_context import (
     get_attn_backend,
     get_req_to_token_pool,
@@ -488,18 +492,30 @@ class Qwen4ExpNGramEmbedding(nn.Module):
             and get_attention_dp_size() > 1
             and not self.use_attn_tp_ngram
         )
-        self.ngram_embedding = VocabParallelEmbedding(
-            padded_vocab_size,
-            self.head_dim_per_ngram,
-            params_dtype=(
-                torch.float8_e4m3fn
-                if (quant_config is not None and quant_config.get_name() == "fp8")
-                or getattr(config, "ple_embedding_dtype", None) == "float8_e4m3fn"
-                else torch.bfloat16
-            ),
-            output_dtype=torch.bfloat16,
-            use_attn_tp_group=self.use_attn_tp_ngram,
+        # With PLE offload the table only ever lives in pinned host memory,
+        # but the stock construction path first materializes the full shard
+        # under the ambient CUDA device (51.2 GB at TP=1) before the
+        # Qwen4ExpPinnedHostEmbedding swap frees it -- an instant OOM on
+        # 32 GB cards. Build the placeholder on CPU instead; the swap deletes
+        # it before any weight bytes are loaded.
+        ngram_construct_ctx = (
+            torch.device("cpu")
+            if getattr(config, "ple_offload_embedding", False)
+            else nullcontext()
         )
+        with ngram_construct_ctx:
+            self.ngram_embedding = VocabParallelEmbedding(
+                padded_vocab_size,
+                self.head_dim_per_ngram,
+                params_dtype=(
+                    torch.float8_e4m3fn
+                    if (quant_config is not None and quant_config.get_name() == "fp8")
+                    or getattr(config, "ple_embedding_dtype", None) == "float8_e4m3fn"
+                    else torch.bfloat16
+                ),
+                output_dtype=torch.bfloat16,
+                use_attn_tp_group=self.use_attn_tp_ngram,
+            )
         self.ngram_embedding.register_buffer(
             "weight_scale", torch.ones(1, dtype=torch.bfloat16), persistent=True
         )
@@ -1584,6 +1600,8 @@ class Qwen4ExpModel(Qwen3_5ForCausalLM):
     decoder_layer_types = ALL_DECODER_LAYER_TYPES
 
     def _build_embed_tokens(self, config: Qwen4ExpTextConfig) -> nn.Module:
+        if not self.pp_group.is_first_rank:
+            return PPMissingLayer()
         return VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
@@ -1608,6 +1626,12 @@ class Qwen4ExpModel(Qwen3_5ForCausalLM):
         )
         if hasattr(self, "norm"):
             delattr(self, "norm")
+        # PP: PLE prep/commit only concern the rank whose layer range holds
+        # the PLE module (layer_id 1 for ple_layer_ids=[2]).
+        self._owns_ple_layer = any(
+            getattr(self.layers[i], "ple", None) is not None
+            for i in range(self.start_layer, self.end_layer)
+        )
         hc_config = HyperConnectionConfig(
             hc_count=self.hc_count,
             hidden_size=self.hidden_size,
@@ -1624,11 +1648,19 @@ class Qwen4ExpModel(Qwen3_5ForCausalLM):
         positions: torch.Tensor,
         forward_batch: ForwardBatch,
         inputs_embeds: Optional[torch.Tensor] = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> torch.Tensor:
-        if inputs_embeds is not None:
-            hidden_states = inputs_embeds
+        if self.pp_group.is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                hidden_states = self.embed_tokens(input_ids)
         else:
-            hidden_states = self.embed_tokens(input_ids)
+            assert pp_proxy_tensors is not None
+            # Already hc-wide ([tokens, hc_count*hidden]); the first local
+            # layer detects the width and skips re-expansion. Matches the
+            # mHC static PP buffer layout (hidden-states only, no residual).
+            hidden_states = pp_proxy_tensors["hidden_states"]
 
         ple_batch = (
             _prepare_ple_batch(
@@ -1637,7 +1669,7 @@ class Qwen4ExpModel(Qwen3_5ForCausalLM):
                 ngram_size=self.ple_ngram_size,
                 ngram_eos_token_id=self.ple_ngram_eos_token_id,
             )
-            if self.has_ple
+            if (self.has_ple and self._owns_ple_layer)
             else None
         )
         residual = None
@@ -1663,6 +1695,9 @@ class Qwen4ExpModel(Qwen3_5ForCausalLM):
                 )
 
         _commit_ple_batch(ple_batch, forward_batch)
+
+        if not self.pp_group.is_last_rank:
+            return PPProxyTensors({"hidden_states": hidden_states})
 
         hc_hidden_states = hidden_states
         hidden_states, _ = self.hyper_connection_mixer.mix(hidden_states)
@@ -1706,6 +1741,7 @@ class Qwen4ExpVLModel(Qwen4ExpModel):
             positions=positions,
             forward_batch=forward_batch,
             inputs_embeds=input_embeds,
+            pp_proxy_tensors=pp_proxy_tensors,
         )
         if isinstance(model_output, tuple):
             hidden_states, self.last_hc_hidden_states = model_output
@@ -1736,8 +1772,25 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
         )
 
     @torch.no_grad()
-    def forward(self, *args, **kwargs):
-        output = super().forward(*args, **kwargs)
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        get_embedding: bool = False,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+        **kwargs,
+    ):
+        # The explicit pp_proxy_tensors kwarg (vs *args/**kwargs) is what the
+        # ModelRunner's support_pp signature probe keys on.
+        output = super().forward(
+            input_ids,
+            positions,
+            forward_batch,
+            get_embedding=get_embedding,
+            pp_proxy_tensors=pp_proxy_tensors,
+            **kwargs,
+        )
         hc_hidden_states = self.model.last_hc_hidden_states
         if hc_hidden_states is not None and isinstance(output, LogitsProcessorOutput):
             output.hidden_states = hc_hidden_states
@@ -1972,6 +2025,14 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
             if ".ple.ple_embedding.ngram_embedding." in name and name.endswith(
                 ".weight"
             ):
+                # PP: shards of a PLE layer outside this rank's range are
+                # legitimately unmatched -- skip, do not raise.
+                ple_layer_id = get_layer_id(name)
+                if ple_layer_id is not None and (
+                    ple_layer_id < self.start_layer
+                    or ple_layer_id >= self.end_layer
+                ):
+                    continue
                 raise ValueError(
                     f"unsupported PLE weight layout (expected shard_N shards): {name}"
                 )


### PR DESCRIPTION
## Summary

This branch takes the Pennyroyal Flash-Next runtime beyond its single-GPU
(TP=1, 96 GB) target and makes **Qwen3.8-Flash-Next-NVFP4 serve PD-disaggregated
on 8x RTX 5090 (32 GB)**: 1 prefill worker at **TP=1 PP=4** + 1 decode worker at
**TP=4 / EP=4 with native NEXTN (MTP)**, mooncake transport, hicache L2 host tier
on the prefill. Everything is validated end-to-end on that topology (details
below); the tree is your `pennyroyal-main-sm120-final` + 8 commits, engine
deps pinned to the same qualified set (run against the stock
`lmsysorg/sglang:nightly-dev-cu13-20260826-41e7612d` image, whose pins match
BUILD.md exactly).

## What's in here (by commit)

**Model side**
- `qwen4_exp` PP wiring: explicit `pp_proxy_tensors` through
  `Qwen4ExpModel/VLModel/ForConditionalGeneration.forward` (hidden-states-only,
  hc-wide proxy — matches the mHC static PP buffers), `PPMissingLayer` embed
  guard off rank 0, PLE prep gated on the owning stage, PLE shards outside the
  local layer range skip instead of raising.
- PLE offload on small-VRAM cards: the n-gram table placeholder now constructs
  under `torch.device("cpu")` when offload is on. Stock code transiently
  materializes the full table shard on GPU before the pinned swap (51.2 GB at
  TP=1) — an instant OOM on 32 GB cards, and the reason this previously needed
  a 96 GB part.

**PD disaggregation** (the fork had no multi-GPU/PD path for this model)
- PLE slot pools built on the PD decode worker (upstream omission; first decode
  forward asserts otherwise).
- Hybrid-model KV pointer pairing by layer id for PP>1 prefills in the generic
  and slice mooncake paths (`get_mha_kv_ptrs_with_pp` mis-addresses dense
  full-attention pointer lists with global `prefill_start_layer` arithmetic).
- **QSA indexer state transfer**: new `QSA_COMPRESSED` (token-page-indexed,
  compressed pages mirror full-KV pages 1:1) and `QSA_RING`
  (`req_pool_idx*ratio + pos%ratio` rows + the layer-independent mRoPE tensor)
  state components — pool accessors, both-side payloads, `force_flat`
  layer-id-paired send. Without this the decode's sparse top-k scores zeros /
  stale pages for the whole transferred prefix: prompts under the indexer
  budget stay accidentally correct, everything longer degrades silently.
- Draft-pool coexistence: the decode publishes main `kv_layer_ids` plus
  positive sentinel ids for the appended draft entries instead of blanking the
  list (blanking kills the layer-id pairing that a spec-less PP prefill needs;
  sentinels must be positive — the bootstrap packs ids as u32).
- PLE n-gram context reconstructed on the decode from the prompt tail (the
  slot-sibling pools are not part of the mamba transfer payload).

**Transport robustness** (bit us on this topology; transport-neutral fixes)
- CHUNK_READY that beats `register_decode_req` is stashed and replayed instead
  of dropped ("Staging chunk arrived for unregistered room" -> 300 s
  `WaitingForInput` timeout under fast transports / bursts).
- The staged-writer fan-in now keys on `prefill_unique_rank` (msg[6] — sent by
  the writer all along, never parsed) instead of the decode session id, which
  is identical across all PP-stage writers; per-writer dedup added.

**HiCache L2 at PP>1**
- `_MambaStrategy.build` rebases the L2 layer mappings to dense stage-local
  ids (+ a density guard). The pools key these by global layer id but the L2
  engine's H->D loop iterates `range(len(mapping))` with `dict.get()` — at
  `pp_rank>0` every host-to-device load is a silent no-op, so host-tier "hits"
  complete with full token counts while restoring nothing. Identity at PP0
  (why a single-GPU deployment never sees it). The same-class issue exists in
  the SWA strategies (`_MambaSwaStrategy`, `_swa_layer_mappings`) — not
  touched here since this model doesn't exercise them.

**nvlink_intra enablement** (ported from a prior campaign; see caveat)
- Transfer executor/worker/decode threads pinned to `kv_args.gpu_id`; aux
  host-buffer engine registration skipped under `SGLANG_MOONCAKE_SEND_AUX_TCP`;
  no parallel per-layer submit for `INTRA_NODE_NVLINK`; `utils.py` returns a
  plain-cudaMalloc `MemPool` (pluggable allocator) for `INTRA_NODE_NVLINK` so
  pools stay `cudaIpcGetMemHandle`-exportable while expandable segments stay
  on; the QSA buffers allocate from that pool too (they are engine-registered).

## Validation (8x RTX 5090, driver 610.57.04, image 20260826-41e7612d + this tree)

- Planted-code recall gate through the full PD pipeline: **10/10** (3k-28k
  token prompts, early/mid needle positions incl. QSA-gate shapes beyond the
  2048 indexer budget, cold + cached), byte-identical prompts also pass on an
  aggregated TP=4/EP=4 control server.
- HiCache L2 gate at PP=4, ratio 6: plant 6x21k-token prompts, flood 755k
  unique tokens (1.5x the device pool), re-ask: **6/6 correct** at
  cached ~20,800/20,840 — host->device restores carry real bytes on every
  stage (pre-fix this "passes" the cache counters and returns garbage).
- NEXTN accept length 3.2-4.0 on natural text; decode 274 tok/s single-stream.
- Prefill 31k tok/s cold aggregate / 73.6k warm (16x ~15k prompts).

## Caveats

- **nvlink_intra could not be exercised on the validation host**: its driver
  (610.57.04 open-kernel-modules P2P build, 12 days uptime) currently fails
  `cudaIpcOpenMemHandle` with `invalid argument` for every device pair — even
  same-device cross-process with a minimal ctypes repro — while
  `nvidia-smi topo -p2p` reports OK (NCCL/VMM paths work; legacy IPC does
  not). The same host measured 41.8 GB/s with this transport eleven days
  earlier on the same module, so this looks like degraded driver state rather
  than a code issue; the ports are included as-is for IPC-capable setups.
- The PLE short-conv window is not transferred by PD (the n-gram context is
  reconstructed; the conv window starts zeroed on the decode) — affects only
  the first few decoded tokens' PLE injection; recall gates unaffected.
- Two boot-time INFO taps were left in deliberately (`[STATE-REG]`, one line
  per rank) plus a debug-level `[QSA-XFER]`; say the word and I'll strip them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #33317015459](https://github.com/jpezzulli/sglang-rtxpro6000/actions/runs/33317015459)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #33317015373](https://github.com/jpezzulli/sglang-rtxpro6000/actions/runs/33317015373)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:warning: [Run #33317015434](https://github.com/jpezzulli/sglang-rtxpro6000/actions/runs/33317015434)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->